### PR TITLE
Allow for multiple FAQ storage folders

### DIFF
--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -1,6 +1,7 @@
 <?php
 namespace Tev\TevFaqs\Domain\Repository;
 
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
@@ -9,15 +10,28 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class CategoryRepository extends Repository
 {
+
+    /**
+     * Configuration manager.
+     *
+     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
+     * @inject
+     */
+    protected $cm;
+
+
     /**
      * {@inheritdoc}
      */
     public function initializeObject()
     {
-        // Remove the PID dependency for objects pulled from this repository
+        $config = $this->cm->getConfiguration(
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
+            'tevfaqs'
+        );
 
         $querySettings = $this->objectManager->get('TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings');
-        $querySettings->setRespectStoragePage(false);
+        $querySettings->setStoragePageIds([$config['persistence']['storagePid']]);
         $this->setDefaultQuerySettings($querySettings);
 
         $this->defaultOrderings = [

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -1,7 +1,6 @@
 <?php
 namespace Tev\TevFaqs\Domain\Repository;
 
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
@@ -10,30 +9,11 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class CategoryRepository extends Repository
 {
-
-    /**
-     * Configuration manager.
-     *
-     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     * @inject
-     */
-    protected $cm;
-
-
     /**
      * {@inheritdoc}
      */
     public function initializeObject()
     {
-        $config = $this->cm->getConfiguration(
-            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
-            'tevfaqs'
-        );
-
-        $querySettings = $this->objectManager->get('TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings');
-        $querySettings->setStoragePageIds([$config['persistence']['storagePid']]);
-        $this->setDefaultQuerySettings($querySettings);
-
         $this->defaultOrderings = [
             'sorting' => QueryInterface::ORDER_ASCENDING
         ];

--- a/Classes/Domain/Repository/FaqRepository.php
+++ b/Classes/Domain/Repository/FaqRepository.php
@@ -1,7 +1,6 @@
 <?php
 namespace Tev\TevFaqs\Domain\Repository;
 
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Tev\TevFaqs\Domain\Model\Category;
 
@@ -10,24 +9,11 @@ use Tev\TevFaqs\Domain\Model\Category;
  */
 class FaqRepository extends Repository
 {
-
-    /**
-     * Configuration manager.
-     *
-     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     * @inject
-     */
-    protected $cm;
-
-
     /**
      * {@inheritdoc}
      */
     public function initializeObject()
     {
-        $querySettings = $this->objectManager->get('TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings');
-        $querySettings->setStoragePageIds([$config['persistence']['storagePid']]);
-        $this->setDefaultQuerySettings($querySettings);
     }
 
     /**

--- a/Classes/Domain/Repository/FaqRepository.php
+++ b/Classes/Domain/Repository/FaqRepository.php
@@ -1,6 +1,7 @@
 <?php
 namespace Tev\TevFaqs\Domain\Repository;
 
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Tev\TevFaqs\Domain\Model\Category;
 
@@ -9,15 +10,23 @@ use Tev\TevFaqs\Domain\Model\Category;
  */
 class FaqRepository extends Repository
 {
+
+    /**
+     * Configuration manager.
+     *
+     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
+     * @inject
+     */
+    protected $cm;
+
+
     /**
      * {@inheritdoc}
      */
     public function initializeObject()
     {
-        // Remove the PID dependency for objects pulled from this repository
-
         $querySettings = $this->objectManager->get('TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings');
-        $querySettings->setRespectStoragePage(false);
+        $querySettings->setStoragePageIds([$config['persistence']['storagePid']]);
         $this->setDefaultQuerySettings($querySettings);
     }
 

--- a/Configuration/Typoscript/constants.ts
+++ b/Configuration/Typoscript/constants.ts
@@ -1,3 +1,12 @@
-plugin.tx_tevfaqs.view.templateRootPath = EXT:tev_faqs/Resources/Private/Templates/
-plugin.tx_tevfaqs.view.partialRootPath = EXT:tev_faqs/Resources/Private/Partials/
-plugin.tx_tevfaqs.view.layoutRootPath = EXT:tev_faqs/Resources/Private/Layouts/
+plugin.tx_tevfaqs {
+    view {
+        templateRootPath = EXT:tev_faqs/Resources/Private/Templates/
+        partialRootPath = EXT:tev_faqs/Resources/Private/Partials/
+        layoutRootPath = EXT:tev_faqs/Resources/Private/Layouts/
+    }
+    persistence {
+        # cat=TEV_faqs/config; type=int+; label=Storage PID
+        storagePid = 0
+    }
+}
+

--- a/Configuration/Typoscript/setup.ts
+++ b/Configuration/Typoscript/setup.ts
@@ -12,4 +12,8 @@ plugin.tx_tevfaqs {
             0 = {$plugin.tx_tevfaqs.view.layoutRootPath}
         }
     }
+
+    persistence {
+        storagePid = {$plugin.tx_tevfaqs.persistence.storagePid}
+    }
 }

--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ $ composer require "3ev/tev_faqs"
 
 ##Usage
 
-Install the TYPO3 extension through the Extension Manager. You'll then be able
-to add FAQ Categories and FAQs from the List View. Each FAQ **must** be categorised
-under a single category. You can add FAQs to any storage folder or page - they
-will be found globally.
+Install the TYPO3 extension through the Extension Manager.
+
+Using the Constants Editor, you should then set the 'TEV_FAQS -> Storage Folder' constant, most likely on your root page template. This will be the main folder that the FAQ Categories and FAQs are stored in.
+
+You'll then be able to add FAQ Categories and FAQs from the List View. Each FAQ **must** be categorised under a single category.
 
 You can then add the FAQs plugin to any page on your site. This plugin will
 display a list of all of the FAQ Categories, with links to the set of the FAQs
 in each category.
+
+You can set the 'Storage Folder' constant on a per page basis if you want a particular page using the FAQs plugin to display a specific set of FAQ categories and FAQs.
 
 ##Styling
 


### PR DESCRIPTION
This change allows for multiple FAQ Storage Folders to be configured so you can have separate FAQ pages.
#### Deployment Notes
- Set the 'TEV_FAQS -> Storage Folder' constant, for the root page template.
