### PR TITLE
INT-1618 | Added back to top buttons

### DIFF
--- a/Resources/Private/Templates/Category/Show.html
+++ b/Resources/Private/Templates/Category/Show.html
@@ -1,4 +1,4 @@
-<div class="row tev-faqs">
+<div class="row tev-faqs include-back-to-top-button">
     <div class="col-sm-4">
         <nav class="list-group tev-faqs__category-nav">
             <f:for each="{categories}" as="cat">
@@ -30,10 +30,6 @@
                                 <dd><f:format.html>{faq.answer}</f:format.html></dd>
                             </f:for>
                         </dl>
-
-                        <a href="{url}#" class="tev-faqs__back-to-top">
-                            <f:translate key="tev_faqs.category.show.back_to_top" />
-                        </a>
                     </f:then>
                     <f:else>
                         <p class="tev-faqs__not-found">


### PR DESCRIPTION
## Tracker/JIRA Issue
* https://jira.3ev.info/browse/INT-1618

## Dev Notes
* Added back to top button to /help/faqs and /help/project-admin pages
* These buttons are the same what they have on /projects/implement-a-project and work the same way
* There was an old, seemingly unused back to top button what I removed

## Deployment Steps
* Clear Typo3 caches

## Testing Notes
* Go to the above mentioned pages and test the back to top buttons
* They work the same way as the one on /projects/implement-a-project page so compare it to that (eg. not showing on small screen)