### PR TITLE
INT-1945 | Added optional "code" column to faq and category tables so specific faqs/categories can be targetted in the codebase

### DIFF
--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -10,6 +10,13 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class Category extends AbstractEntity
 {
     /**
+     * Code.
+     *
+     * @var string
+     */
+    protected $code;
+
+    /**
      * Title.
      *
      * @var string
@@ -35,6 +42,26 @@ class Category extends AbstractEntity
     public function __construct()
     {
         $this->faqs = new ObjectStorage;
+    }
+
+    /**
+     * Returns the code.
+     *
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * Sets the code.
+     *
+     * @param  string $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
     }
 
     /**

--- a/Classes/Domain/Model/Faq.php
+++ b/Classes/Domain/Model/Faq.php
@@ -9,6 +9,13 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Faq extends AbstractEntity
 {
     /**
+     * Code.
+     *
+     * @var string
+     */
+    protected $code;
+
+    /**
      * Question.
      *
      * @var string
@@ -31,6 +38,26 @@ class Faq extends AbstractEntity
      * @lazy
      */
     protected $category;
+
+    /**
+     * Returns the code.
+     *
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * Sets the code.
+     *
+     * @param  string $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
 
     /**
      * Returns the question.

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -11,6 +11,7 @@ CREATE TABLE tx_tevfaqs_domain_model_category (
     deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,
     hidden tinyint(4) unsigned DEFAULT '0' NOT NULL,
     sorting int(11) DEFAULT '0' NOT NULL,
+    code varchar(255),
     title varchar(255) DEFAULT '' NOT NULL,
     faqs int(11) unsigned DEFAULT '0' NOT NULL,
 
@@ -33,6 +34,7 @@ CREATE TABLE tx_tevfaqs_domain_model_faq (
     deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,
     hidden tinyint(4) unsigned DEFAULT '0' NOT NULL,
     sorting int(11) DEFAULT '0' NOT NULL,
+    code varchar(255),
     question varchar(255) DEFAULT '' NOT NULL,
     answer text NOT NULL,
     category int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
## Tracker/JIRA Issue
* https://jira.3ev.info/browse/INT-1945

## Dev Notes
* Interreg wants to be able to go to a specific FAQ on their FAQs page. This change will add a 'code' column to the faqs table so that a string can be specified for each FAQ, which will allow us to target that specific FAQ in thec odebase without relying on a uid

## Deployment Steps
* No additional steps required

## Testing Notes
N/A