### PR TITLE
INT-1979 | FAQ & Project Microsite FAQ merged

### DIFF
--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -14,10 +14,6 @@ class CategoryRepository extends Repository
      */
     public function initializeObject()
     {
-        $querySettings = $this->objectManager->get('TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings');
-        $querySettings->setRespectStoragePage(false);
-        $this->setDefaultQuerySettings($querySettings);
-
         $this->defaultOrderings = [
             'sorting' => QueryInterface::ORDER_ASCENDING
         ];

--- a/Configuration/TCA/tx_tevfaqs_domain_model_category.php
+++ b/Configuration/TCA/tx_tevfaqs_domain_model_category.php
@@ -63,14 +63,6 @@ return [
                 ]
             ]
         ],
-        'code' => [
-            'exclude' => 1,
-            'label' => 'LLL:EXT:tev_faqs/Resources/Private/Language/locallang_tca.xml:tx_tevfaqs_domain_model_category.code',
-            'config' => [
-                'type' => 'input',
-                'size' => '30',
-                'eval' => 'trim, required'
-            ]
-        ]
     ]
 ];
+

--- a/Configuration/TCA/tx_tevfaqs_domain_model_faq.php
+++ b/Configuration/TCA/tx_tevfaqs_domain_model_faq.php
@@ -65,14 +65,5 @@ return [
                 'size' => 1
             ]
         ],
-        'code' => [
-            'exclude' => 1,
-            'label' => 'LLL:EXT:tev_faqs/Resources/Private/Language/locallang_tca.xml:tx_tevfaqs_domain_model_faq.code',
-            'config' => [
-                'type' => 'input',
-                'size' => '30',
-                'eval' => 'trim, required'
-            ]
-        ]
     ]
 ];

--- a/Resources/Private/Language/locallang_tca.xml
+++ b/Resources/Private/Language/locallang_tca.xml
@@ -15,7 +15,6 @@
             <label index="tx_tevfaqs_domain_model_faq.question">Question</label>
             <label index="tx_tevfaqs_domain_model_faq.answer">Answer</label>
             <label index="tx_tevfaqs_domain_model_faq.category">FAQ Category</label>
-            <label index="tx_tevfaqs_domain_model_faq.code">Code</label>
         </languageKey>
     </data>
 </T3locallang>


### PR DESCRIPTION
## Jira Task
Task originally for Interreg:
- [INT-1979 | FAQ & Project Microsite FAQ merged](https://jira.3ev.info/browse/INT-1979)
## Dev Notes
- The last changes of the FAQ plugin affected Interreg FAQ's sections, merging categories from different folders when it shouldn't and creating a required input not meant to be in the typo3 cms called "code". 
- The changes remove the "code" input field and the other unrequested changes.
## Deployment notes
- Update composer.json on your Interreg project to use this branch of the package.
-  On "FAQ" 'Example FAQ' link may be present, this should be deleted from the database (yours and client's).
## Testing Notes -> test Interreg-Europe:
- **Testing on site**
- Go to your Interreg local build.
- Go to the navigation bar, hoover over "Help" and click "FAQ".
-  On "FAQ" 'Example FAQ' link may be present, this should be deleted from the database:  see deploy notes. 
-  On your-local-interreg/help/faqs/ you should have a column with 14 links. Compare to live where there's about 30 at the moment, due to the merge of both categories.
-  From FAQ page click on "Find more answers" (Right hand side box)
- On your-local-interreg/help/project-admin/ you should have a column with 16 links. Compare to live where there's about 30 at the moment, due to the merge of both categories.
- If this two pages have 14 and 16 links also sending a 'good practice' must be available. (Click " My Interreg Europe", login, click on "Good Practices", go to "Submit a Good Practice", fill up the questionnaire and submit it)
- **Testing on Typo3**
- In typo3:  FAQs folder and Project Microsite FAQs folder contain FAQ questions. This questions should not have at the end of it ,right after the FAQ Category dropdown list, a "code" mandatory field (that field is now deleted from the code).
- Go to your-local-interreg/typo3
- Click list and navigate to Storage. Inside there's two folders, FAQS and Project Microsite FAQs. Both have the same structure so this implies the same testing for both folders.
- Click one of them. There's two boxes, the second one with the subtitle "Question". Click any of the questions.
- Scroll down and at the end of the question there should be no input field with the tittle Code at all.
- Check the other folder following the same steps.
